### PR TITLE
Add RESPONSE_STREAM toggle and improve Lambda streaming response handling

### DIFF
--- a/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaApplication.java
+++ b/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaApplication.java
@@ -28,16 +28,21 @@ public class LambdaApplication {
     public static void startHandle(AbstractServerConfig serverConfig) throws Exception {
         LambdaEventIterator lambdaEventIterator = new LambdaEventIterator();
         LambdaHandler lambdaHandler = new LambdaHandler(serverConfig);
+        boolean responseStreamEnabled = isResponseStreamEnabled();
         //处理请求
         while (lambdaEventIterator.hasNext()) {
             Map.Entry<String, LambdaApiGatewayRequest> requestInfo = lambdaEventIterator.next();
-            boolean eventStream = Objects.equals(requestInfo.getValue().getHeaders().get("Accept"), "text/event-stream");
-            if (eventStream) {
+            if (responseStreamEnabled) {
                 lambdaHandler.doStreamingHandle(requestInfo.getValue(), requestInfo.getKey(), lambdaEventIterator.getHttpClient());
             } else {
                 LambdaApiGatewayResponse apiGatewayResponse = lambdaHandler.doHandle(requestInfo.getValue());
                 lambdaEventIterator.report(apiGatewayResponse, requestInfo.getKey());
             }
         }
+    }
+
+    private static boolean isResponseStreamEnabled() {
+        String invokeMode = System.getenv("SWS_LAMBDA_INVOKE_MODE");
+        return Objects.equals("RESPONSE_STREAM", invokeMode);
     }
 }

--- a/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaStreamingHttpResponseWrapper.java
+++ b/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaStreamingHttpResponseWrapper.java
@@ -12,8 +12,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -33,10 +33,11 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
 
     private final String requestId;
     private final HttpClient httpClient;
-    private int statusCode;
+    private int statusCode = 200;
     private boolean headerSent;
     private OutputStream runtimeOutputStream;
     private java.net.http.HttpResponse<InputStream> runtimeResponse;
+    private Thread senderThread;
 
     public LambdaStreamingHttpResponseWrapper(HttpRequest request, ResponseConfig responseConfig,
                                               String requestId, HttpClient httpClient) {
@@ -67,7 +68,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
     @Override
     protected void send(byte[] bytes, boolean body, boolean close) {
         try {
-            if (!headerSent && body) {
+            if (!headerSent && (body || close)) {
                 sendStreamingPrelude();
                 headerSent = true;
             }
@@ -77,6 +78,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
             }
             if (close && runtimeOutputStream != null) {
                 runtimeOutputStream.close();
+                awaitRuntimeResponse();
             }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Lambda streaming write error: " + e.getMessage());
@@ -98,7 +100,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
         StringBuilder jsonPrelude = new StringBuilder();
         jsonPrelude.append("{\"statusCode\":").append(statusCode);
         jsonPrelude.append(",\"headers\":{");
-        Map<String, String> responseHeaders = getHeader();
+        Map<String, String> responseHeaders = filterResponseHeaders(getHeader());
         if (responseHeaders != null && !responseHeaders.isEmpty()) {
             String headersJson = responseHeaders.entrySet().stream()
                     .map(e -> "\"" + escapeJson(e.getKey()) + "\":\"" + escapeJson(e.getValue()) + "\"")
@@ -117,7 +119,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
         String url = getRuntimeApiBaseUrl() + "/" + requestId + "/response";
 
         // 在后台线程发起 HTTP 请求到 Lambda Runtime API
-        Thread senderThread = new Thread(() -> {
+        senderThread = new Thread(() -> {
             try {
                 java.net.http.HttpRequest runtimeRequest = java.net.http.HttpRequest.newBuilder()
                         .uri(URI.create(url))
@@ -131,7 +133,6 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
                 LOGGER.log(Level.WARNING, "Lambda Runtime API streaming request error: " + e.getMessage());
             }
         }, "lambda-streaming-sender");
-        senderThread.setDaemon(true);
         senderThread.start();
 
         // 保存 outputStream 以供后续 send() 调用使用
@@ -154,6 +155,40 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
                 runtimeOutputStream.close();
             } catch (IOException ignored) {
             }
+        }
+    }
+
+    private static Map<String, String> filterResponseHeaders(Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return headers;
+        }
+        Map<String, String> targetHeaders = new HashMap<>();
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            String lowerCaseKey = key.toLowerCase();
+            if ("content-length".equals(lowerCaseKey) || "connection".equals(lowerCaseKey) || "transfer-encoding".equals(lowerCaseKey)) {
+                continue;
+            }
+            targetHeaders.put(key, entry.getValue());
+        }
+        return targetHeaders;
+    }
+
+    private void awaitRuntimeResponse() {
+        if (senderThread == null) {
+            return;
+        }
+        try {
+            senderThread.join(3000);
+            if (runtimeResponse != null && runtimeResponse.statusCode() >= 400) {
+                LOGGER.warning("Lambda Runtime API streaming response error: status = " + runtimeResponse.statusCode());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.WARNING, "Interrupted while waiting runtime response", e);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Allow the Lambda runtime to opt into response-streaming mode via an environment flag instead of relying on request headers.
- Fix header handling and lifecycle management for streaming responses to avoid sending disallowed headers and to wait for runtime errors.

### Description
- Use a new environment check `isResponseStreamEnabled()` (reads `SWS_LAMBDA_INVOKE_MODE`) in `LambdaApplication.startHandle` to decide streaming behavior instead of checking the `Accept` header.
- Add `isResponseStreamEnabled()` helper to `LambdaApplication` to detect `RESPONSE_STREAM` mode.
- In `LambdaStreamingHttpResponseWrapper` set a default `statusCode` of `200` and change prelude send logic to trigger on first body write or on close.
- Filter out `Content-Length`, `Connection`, and `Transfer-Encoding` headers before building the streaming JSON prelude via a new `filterResponseHeaders` method.
- Use a dedicated `senderThread` field and add `awaitRuntimeResponse()` to `join` the streaming sender (with timeout) and log runtime API errors when the stream is closed.
- Minor imports and variable adjustments to support the new behavior and header filtering.

### Testing
- Built the project and executed the test suite with `mvn -DskipTests=false test`, and existing automated tests completed successfully.
- Verified the streaming code paths by exercising `LambdaStreamingHttpResponseWrapper.send` behavior in local runs to ensure prelude emission, header filtering, and runtime response wait logic functioned as expected.
- No new unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5bc383c38832d98e1e88a7fb694cd)