### PR TITLE
Add RESPONSE_STREAM mode & improve Lambda streaming response wrapper

### DIFF
--- a/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaApplication.java
+++ b/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaApplication.java
@@ -28,16 +28,21 @@ public class LambdaApplication {
     public static void startHandle(AbstractServerConfig serverConfig) throws Exception {
         LambdaEventIterator lambdaEventIterator = new LambdaEventIterator();
         LambdaHandler lambdaHandler = new LambdaHandler(serverConfig);
+        boolean responseStreamEnabled = isResponseStreamEnabled();
         //处理请求
         while (lambdaEventIterator.hasNext()) {
             Map.Entry<String, LambdaApiGatewayRequest> requestInfo = lambdaEventIterator.next();
-            boolean eventStream = Objects.equals(requestInfo.getValue().getHeaders().get("Accept"), "text/event-stream");
-            if (eventStream) {
+            if (responseStreamEnabled) {
                 lambdaHandler.doStreamingHandle(requestInfo.getValue(), requestInfo.getKey(), lambdaEventIterator.getHttpClient());
             } else {
                 LambdaApiGatewayResponse apiGatewayResponse = lambdaHandler.doHandle(requestInfo.getValue());
                 lambdaEventIterator.report(apiGatewayResponse, requestInfo.getKey());
             }
         }
+    }
+
+    private static boolean isResponseStreamEnabled() {
+        String invokeMode = System.getenv("SWS_LAMBDA_INVOKE_MODE");
+        return Objects.equals("RESPONSE_STREAM", invokeMode);
     }
 }

--- a/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaStreamingHttpResponseWrapper.java
+++ b/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaStreamingHttpResponseWrapper.java
@@ -12,8 +12,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -33,10 +33,11 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
 
     private final String requestId;
     private final HttpClient httpClient;
-    private int statusCode;
+    private int statusCode = 200;
     private boolean headerSent;
     private OutputStream runtimeOutputStream;
     private java.net.http.HttpResponse<InputStream> runtimeResponse;
+    private Thread senderThread;
 
     public LambdaStreamingHttpResponseWrapper(HttpRequest request, ResponseConfig responseConfig,
                                               String requestId, HttpClient httpClient) {
@@ -49,6 +50,19 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
     protected boolean needChunked(InputStream inputStream, long bodyLength) {
         // 始终返回 true 以触发 chunked 写入路径
         return inputStream != null;
+    }
+
+    @Override
+    protected byte[] toChunkedBytes(byte[] inputBytes) {
+        // Lambda Runtime API streaming 的 HTTP 分块由底层连接处理，
+        // 这里不应再把业务数据包装成 HTTP chunk 帧（避免双重 chunked）。
+        return inputBytes;
+    }
+
+    @Override
+    protected byte[] toCloseChunkedBytes() {
+        // 结束流通过关闭 runtimeOutputStream 即可，这里不发送额外 chunk 结束帧。
+        return new byte[0];
     }
 
     private String getRuntimeApiBaseUrl() {
@@ -67,7 +81,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
     @Override
     protected void send(byte[] bytes, boolean body, boolean close) {
         try {
-            if (!headerSent && body) {
+            if (!headerSent && (body || close)) {
                 sendStreamingPrelude();
                 headerSent = true;
             }
@@ -77,6 +91,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
             }
             if (close && runtimeOutputStream != null) {
                 runtimeOutputStream.close();
+                awaitRuntimeResponse();
             }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Lambda streaming write error: " + e.getMessage());
@@ -98,7 +113,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
         StringBuilder jsonPrelude = new StringBuilder();
         jsonPrelude.append("{\"statusCode\":").append(statusCode);
         jsonPrelude.append(",\"headers\":{");
-        Map<String, String> responseHeaders = getHeader();
+        Map<String, String> responseHeaders = filterResponseHeaders(getHeader());
         if (responseHeaders != null && !responseHeaders.isEmpty()) {
             String headersJson = responseHeaders.entrySet().stream()
                     .map(e -> "\"" + escapeJson(e.getKey()) + "\":\"" + escapeJson(e.getValue()) + "\"")
@@ -117,7 +132,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
         String url = getRuntimeApiBaseUrl() + "/" + requestId + "/response";
 
         // 在后台线程发起 HTTP 请求到 Lambda Runtime API
-        Thread senderThread = new Thread(() -> {
+        senderThread = new Thread(() -> {
             try {
                 java.net.http.HttpRequest runtimeRequest = java.net.http.HttpRequest.newBuilder()
                         .uri(URI.create(url))
@@ -131,7 +146,6 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
                 LOGGER.log(Level.WARNING, "Lambda Runtime API streaming request error: " + e.getMessage());
             }
         }, "lambda-streaming-sender");
-        senderThread.setDaemon(true);
         senderThread.start();
 
         // 保存 outputStream 以供后续 send() 调用使用
@@ -154,6 +168,40 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
                 runtimeOutputStream.close();
             } catch (IOException ignored) {
             }
+        }
+    }
+
+    private static Map<String, String> filterResponseHeaders(Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return headers;
+        }
+        Map<String, String> targetHeaders = new HashMap<>();
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            String lowerCaseKey = key.toLowerCase();
+            if ("content-length".equals(lowerCaseKey) || "connection".equals(lowerCaseKey) || "transfer-encoding".equals(lowerCaseKey)) {
+                continue;
+            }
+            targetHeaders.put(key, entry.getValue());
+        }
+        return targetHeaders;
+    }
+
+    private void awaitRuntimeResponse() {
+        if (senderThread == null) {
+            return;
+        }
+        try {
+            senderThread.join(3000);
+            if (runtimeResponse != null && runtimeResponse.statusCode() >= 400) {
+                LOGGER.warning("Lambda Runtime API streaming response error: status = " + runtimeResponse.statusCode());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.WARNING, "Interrupted while waiting runtime response", e);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Enable using Lambda Runtime Response Streaming when the function is configured in streaming mode instead of relying on the `Accept: text/event-stream` header.
- Prevent double-chunking and problematic headers when streaming responses to the Lambda Runtime API.
- Ensure the streaming sender thread is tracked and its response is awaited to surface runtime API errors.

### Description
- Added `isResponseStreamEnabled()` and switched `startHandle` to use the `SWS_LAMBDA_INVOKE_MODE=RESPONSE_STREAM` environment variable to decide streaming behavior instead of checking request headers.
- Enhanced `LambdaStreamingHttpResponseWrapper` by initializing `statusCode` to `200`, adding a `senderThread` field, and exposing `awaitRuntimeResponse()` to join the sender and log runtime response errors.
- Implemented `toChunkedBytes()` and `toCloseChunkedBytes()` to avoid double HTTP chunk framing and simplified `send()` to send the JSON prelude when sending body or on close, and to close and await the runtime response when complete.
- Filtered response headers with `filterResponseHeaders()` to remove `Content-Length`, `Connection`, and `Transfer-Encoding` before including them in the JSON prelude, and switched to using a non-daemon sender thread that populates `runtimeResponse`.

### Testing
- Ran unit tests with `mvn test` on the modified module and the test suite completed successfully.
- Verified streaming wrapper behavior via automated tests that exercise `send()`/close paths and the runtime request sender, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5bc383c38832d98e1e88a7fb694cd)