### PR TITLE
Support AWS Lambda RESPONSE_STREAM mode and streaming HTTP response wrapper improvements

### DIFF
--- a/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaApplication.java
+++ b/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaApplication.java
@@ -28,16 +28,21 @@ public class LambdaApplication {
     public static void startHandle(AbstractServerConfig serverConfig) throws Exception {
         LambdaEventIterator lambdaEventIterator = new LambdaEventIterator();
         LambdaHandler lambdaHandler = new LambdaHandler(serverConfig);
+        boolean responseStreamEnabled = isResponseStreamEnabled();
         //处理请求
         while (lambdaEventIterator.hasNext()) {
             Map.Entry<String, LambdaApiGatewayRequest> requestInfo = lambdaEventIterator.next();
-            boolean eventStream = Objects.equals(requestInfo.getValue().getHeaders().get("Accept"), "text/event-stream");
-            if (eventStream) {
+            if (responseStreamEnabled) {
                 lambdaHandler.doStreamingHandle(requestInfo.getValue(), requestInfo.getKey(), lambdaEventIterator.getHttpClient());
             } else {
                 LambdaApiGatewayResponse apiGatewayResponse = lambdaHandler.doHandle(requestInfo.getValue());
                 lambdaEventIterator.report(apiGatewayResponse, requestInfo.getKey());
             }
         }
+    }
+
+    private static boolean isResponseStreamEnabled() {
+        String invokeMode = System.getenv("SWS_LAMBDA_INVOKE_MODE");
+        return Objects.equals("RESPONSE_STREAM", invokeMode);
     }
 }

--- a/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaStreamingHttpResponseWrapper.java
+++ b/simplewebserver-lambda-function-impl/src/main/java/com/hibegin/lambda/LambdaStreamingHttpResponseWrapper.java
@@ -12,8 +12,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -33,10 +33,11 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
 
     private final String requestId;
     private final HttpClient httpClient;
-    private int statusCode;
+    private int statusCode = 200;
     private boolean headerSent;
     private OutputStream runtimeOutputStream;
     private java.net.http.HttpResponse<InputStream> runtimeResponse;
+    private Thread senderThread;
 
     public LambdaStreamingHttpResponseWrapper(HttpRequest request, ResponseConfig responseConfig,
                                               String requestId, HttpClient httpClient) {
@@ -47,8 +48,8 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
 
     @Override
     protected boolean needChunked(InputStream inputStream, long bodyLength) {
-        // 始终返回 true 以触发 chunked 写入路径
-        return inputStream != null;
+        // 流式由 Runtime API 连接本身承载，不依赖 SimpleHttpResponse 的 chunked/gzip 路径
+        return false;
     }
 
     private String getRuntimeApiBaseUrl() {
@@ -67,7 +68,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
     @Override
     protected void send(byte[] bytes, boolean body, boolean close) {
         try {
-            if (!headerSent && body) {
+            if (!headerSent && (body || close)) {
                 sendStreamingPrelude();
                 headerSent = true;
             }
@@ -77,6 +78,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
             }
             if (close && runtimeOutputStream != null) {
                 runtimeOutputStream.close();
+                awaitRuntimeResponse();
             }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Lambda streaming write error: " + e.getMessage());
@@ -87,6 +89,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
     @Override
     protected byte[] wrapperBaseResponseHeader(int statusCode) {
         this.statusCode = statusCode;
+        putHeader("Connection", "close");
         return super.wrapperBaseResponseHeader(statusCode);
     }
 
@@ -98,7 +101,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
         StringBuilder jsonPrelude = new StringBuilder();
         jsonPrelude.append("{\"statusCode\":").append(statusCode);
         jsonPrelude.append(",\"headers\":{");
-        Map<String, String> responseHeaders = getHeader();
+        Map<String, String> responseHeaders = filterResponseHeaders(getHeader());
         if (responseHeaders != null && !responseHeaders.isEmpty()) {
             String headersJson = responseHeaders.entrySet().stream()
                     .map(e -> "\"" + escapeJson(e.getKey()) + "\":\"" + escapeJson(e.getValue()) + "\"")
@@ -117,7 +120,7 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
         String url = getRuntimeApiBaseUrl() + "/" + requestId + "/response";
 
         // 在后台线程发起 HTTP 请求到 Lambda Runtime API
-        Thread senderThread = new Thread(() -> {
+        senderThread = new Thread(() -> {
             try {
                 java.net.http.HttpRequest runtimeRequest = java.net.http.HttpRequest.newBuilder()
                         .uri(URI.create(url))
@@ -131,7 +134,6 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
                 LOGGER.log(Level.WARNING, "Lambda Runtime API streaming request error: " + e.getMessage());
             }
         }, "lambda-streaming-sender");
-        senderThread.setDaemon(true);
         senderThread.start();
 
         // 保存 outputStream 以供后续 send() 调用使用
@@ -154,6 +156,40 @@ public class LambdaStreamingHttpResponseWrapper extends SimpleHttpResponse {
                 runtimeOutputStream.close();
             } catch (IOException ignored) {
             }
+        }
+    }
+
+    private static Map<String, String> filterResponseHeaders(Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return headers;
+        }
+        Map<String, String> targetHeaders = new HashMap<>();
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            String lowerCaseKey = key.toLowerCase();
+            if ("content-length".equals(lowerCaseKey) || "connection".equals(lowerCaseKey) || "transfer-encoding".equals(lowerCaseKey)) {
+                continue;
+            }
+            targetHeaders.put(key, entry.getValue());
+        }
+        return targetHeaders;
+    }
+
+    private void awaitRuntimeResponse() {
+        if (senderThread == null) {
+            return;
+        }
+        try {
+            senderThread.join(3000);
+            if (runtimeResponse != null && runtimeResponse.statusCode() >= 400) {
+                LOGGER.warning("Lambda Runtime API streaming response error: status = " + runtimeResponse.statusCode());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.WARNING, "Interrupted while waiting runtime response", e);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Enable handling of AWS Lambda Function URL `RESPONSE_STREAM` invoke mode so responses can be streamed back to clients via the Lambda Runtime API instead of being fully buffered.
- Ensure headers and runtime interactions conform to the Lambda Response Streaming protocol and avoid sending problematic hop-by-hop headers.

### Description
- Add detection of response-streaming mode by reading `SWS_LAMBDA_INVOKE_MODE` in `LambdaApplication` and branch to streaming handling when it equals `RESPONSE_STREAM` instead of relying on `Accept: text/event-stream` header.
- Implement streaming-aware response wrapper `LambdaStreamingHttpResponseWrapper` changes: set default `statusCode` to `200`, change `needChunked` to `false`, set `Connection: close` in `wrapperBaseResponseHeader`, and ensure prelude is sent when either body or close is requested.
- Open a background HTTP request to the Lambda Runtime API using piped streams, keep a reference to the sender thread and runtime `HttpResponse`, and wait for the runtime response on close via `awaitRuntimeResponse` to log any server-side errors.
- Filter out hop-by-hop and conflicting headers (`Content-Length`, `Connection`, `Transfer-Encoding`) before constructing the JSON prelude using the new `filterResponseHeaders` helper.

### Testing
- Built the project and exercised the modified Lambda startup and streaming response flow locally in a Lambda-like environment; the streaming path established a runtime connection and sent prelude + body chunks without retaining `Content-Length`/`Connection` headers.
- Ran the existing automated test suite; tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5bc383c38832d98e1e88a7fb694cd)